### PR TITLE
Remove "Hire Me" CTA and make Contact button copy email to clipboard

### DIFF
--- a/index.css
+++ b/index.css
@@ -122,7 +122,6 @@ a {
   color: #f6f3ee;
 }
 
-.hire-button,
 .primary-action {
   display: inline-flex;
   align-items: center;
@@ -194,6 +193,9 @@ a {
   border-radius: 1rem;
   border: 1px solid rgba(198, 154, 63, 0.35);
   color: #d5b15a;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
 }
 
 .hero-stats {
@@ -807,8 +809,7 @@ a {
     gap: 1.25rem;
   }
 
-  .brand-mark,
-  .hire-button {
+  .brand-mark {
     min-width: auto;
   }
 
@@ -846,7 +847,7 @@ a {
   }
 
   .hero-actions a,
-  .hire-button {
+  .hero-actions button {
     width: 100%;
   }
 

--- a/index.html
+++ b/index.html
@@ -22,9 +22,6 @@
           <a href="#contact">Contact</a>
         </nav>
 
-        <a class="hire-button" href="mailto:acbjohnson2002@gmail.com"
-          >Hire Me</a
-        >
       </header>
 
       <section class="hero-section" id="about">
@@ -47,9 +44,14 @@
 
           <div class="hero-actions">
             <a class="primary-action" href="#work">View My Work</a>
-            <a class="secondary-action" href="mailto:acbjohnson2002@gmail.com"
-              >Contact Me</a
+            <button
+              class="secondary-action"
+              id="contact-copy-button"
+              type="button"
+              aria-label="Copy acbjohnson2002@gmail.com to clipboard"
             >
+              Contact Me
+            </button>
           </div>
 
           <div class="hero-stats" aria-label="Career highlights">
@@ -159,7 +161,9 @@
 
     <script>
       const roles = ["Software Engineer", "Game Developer", "UX Designer"];
+      const emailAddress = "acbjohnson2002@gmail.com";
       const roleEl = document.getElementById("hero-role");
+      const contactCopyButtonEl = document.getElementById("contact-copy-button");
       const projectGridEl = document.getElementById("project-grid");
       const experienceTimelineEl = document.getElementById("experience-timeline");
       const toolsGridEl = document.getElementById("tools-grid");
@@ -178,6 +182,20 @@
 
       function scrollToTop() {
         window.scrollTo({ top: 0, behavior: "smooth" });
+      }
+
+      async function copyEmailToClipboard() {
+        try {
+          await navigator.clipboard.writeText(emailAddress);
+          contactCopyButtonEl.textContent = "Email Copied!";
+        } catch (error) {
+          console.error(error);
+          contactCopyButtonEl.textContent = "Copy Failed";
+        }
+
+        window.setTimeout(() => {
+          contactCopyButtonEl.textContent = "Contact Me";
+        }, 2000);
       }
 
       function tick() {
@@ -396,6 +414,7 @@
       mobileCardQuery.addEventListener("change", syncMobileCardEffects);
       window.addEventListener("scroll", updateScrollTopButton, { passive: true });
       scrollTopButtonEl.addEventListener("click", scrollToTop);
+      contactCopyButtonEl.addEventListener("click", copyEmailToClipboard);
 
       setTimeout(tick, 1200);
       loadProjects();

--- a/my-app/src/components/HomePage.css
+++ b/my-app/src/components/HomePage.css
@@ -71,7 +71,6 @@
   color: #f6f3ee;
 }
 
-.hire-button,
 .primary-action {
   display: inline-flex;
   align-items: center;
@@ -144,6 +143,9 @@
   border-radius: 1rem;
   border: 1px solid rgba(198, 154, 63, 0.35);
   color: #d5b15a;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
 }
 
 .hero-stats {
@@ -180,8 +182,6 @@
   min-height: 44rem;
   align-items: center;
 }
-
-
 
 .featured-projects {
   padding: 1rem 2rem 5rem;
@@ -320,8 +320,7 @@
     flex-wrap: wrap;
   }
 
-  .brand-mark,
-  .hire-button {
+  .brand-mark {
     min-width: auto;
   }
 

--- a/my-app/src/components/HomePage.js
+++ b/my-app/src/components/HomePage.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import './HomePage.css';
 import LanyardCard from './LanyardCard';
 
@@ -10,10 +10,13 @@ const stats = [
 
 const navItems = ['Work', 'Experience', 'About', 'Contact'];
 const roles = ['Software Engineer', 'Game Developer', 'UX Designer'];
+const emailAddress = 'acbjohnson2002@gmail.com';
 
 function HomePage() {
   const [roleText, setRoleText] = useState(roles[0]);
   const [projects, setProjects] = useState([]);
+  const [contactMessage, setContactMessage] = useState('Contact Me');
+  const contactTimeoutRef = useRef(null);
 
   useEffect(() => {
     let roleIndex = 0;
@@ -56,6 +59,30 @@ function HomePage() {
 
     return () => clearTimeout(timeoutId);
   }, []);
+
+  useEffect(() => () => {
+    if (contactTimeoutRef.current) {
+      clearTimeout(contactTimeoutRef.current);
+    }
+  }, []);
+
+  const handleContactClick = async () => {
+    try {
+      await navigator.clipboard.writeText(emailAddress);
+      setContactMessage('Email Copied!');
+    } catch (error) {
+      console.error(error);
+      setContactMessage('Copy Failed');
+    }
+
+    if (contactTimeoutRef.current) {
+      clearTimeout(contactTimeoutRef.current);
+    }
+
+    contactTimeoutRef.current = setTimeout(() => {
+      setContactMessage('Contact Me');
+    }, 2000);
+  };
 
   useEffect(() => {
     let isMounted = true;
@@ -100,10 +127,6 @@ function HomePage() {
             </a>
           ))}
         </nav>
-
-        <a className="hire-button" href="mailto:acbjohnson2002@gmail.com">
-          Hire Me
-        </a>
       </header>
 
       <section className="hero-section">
@@ -124,9 +147,14 @@ function HomePage() {
             <a className="primary-action" href="#work">
               View My Work
             </a>
-            <a className="secondary-action" href="mailto:acbjohnson2002@gmail.com">
-              Contact Me
-            </a>
+            <button
+              type="button"
+              className="secondary-action"
+              onClick={handleContactClick}
+              aria-label={`Copy ${emailAddress} to clipboard`}
+            >
+              {contactMessage}
+            </button>
           </div>
 
           <div className="hero-stats" aria-label="Career highlights">


### PR DESCRIPTION
### Motivation
- Simplify the header by removing the duplicate "Hire Me" mailto CTA that duplicated the contact intent in the hero.
- Make contacting easier by copying the site owner's email to the visitor's clipboard from the hero action rather than opening a mail client.
- Preserve the existing visual treatment while converting the control to a semantic button with transient success/failure feedback.

### Description
- Replaced the header `Hire Me` anchor with no visible CTA and converted the hero `Contact Me` anchor into a button that calls `handleContactClick` in `my-app/src/components/HomePage.js`.
- Added `emailAddress` constant, `contactMessage` state, a `contactTimeoutRef` `useRef`, and `handleContactClick` which uses `navigator.clipboard.writeText(...)` and shows temporary feedback (`Email Copied!` / `Copy Failed`).
- Ensured timeouts are cleared on unmount to avoid leaks by cleaning `contactTimeoutRef` in an effect.
- Updated `my-app/src/components/HomePage.css` to remove `.hire-button` references and adjust `.secondary-action` styling so the new button visually matches the original design and behaves as a button on mobile.

### Testing
- Ran `npm run build` and it failed because `react-scripts` is not available in the current environment (error: `sh: 1: react-scripts: not found`).
- Ran `CI=true npm test -- --watch=false` and it failed for the same reason (`react-scripts` not found) and also encountered an `npm` registry 403 when attempting `npm install` in this environment.
- The code changes were committed locally (`git` commit successful) but full build/test could not complete due to the environment package restrictions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc36290698832691ba0b7b82b9a000)