### PR TITLE
Prevent hero role text from shifting layout

### DIFF
--- a/index.css
+++ b/index.css
@@ -194,9 +194,12 @@ a {
 
 .typewriter-role {
   display: inline-flex;
-  min-width: 16ch;
+  width: min(var(--typewriter-width, 18ch), 100%);
+  min-height: 1.1em;
   margin-left: 0.2em;
   white-space: nowrap;
+  overflow: hidden;
+  vertical-align: bottom;
 }
 
 .typewriter-role-text::after {
@@ -936,11 +939,13 @@ a {
   }
 
   .typewriter-role {
-    min-width: 0;
     display: block;
+    width: min(var(--typewriter-width, 18ch), 100%);
+    min-height: 1.1em;
     margin-left: 0;
     margin-top: 0.2em;
-    white-space: normal;
+    white-space: nowrap;
+    overflow: hidden;
   }
 
   .hero-actions {

--- a/index.css
+++ b/index.css
@@ -197,6 +197,7 @@ a {
   width: min(var(--typewriter-width, 18ch), 100%);
   min-height: 1.1em;
   margin-left: 0.2em;
+  font-size: 0.92em;
   white-space: nowrap;
   overflow: hidden;
   vertical-align: bottom;
@@ -944,6 +945,7 @@ a {
     min-height: 1.1em;
     margin-left: 0;
     margin-top: 0.2em;
+    font-size: 0.92em;
     white-space: nowrap;
     overflow: hidden;
   }

--- a/index.html
+++ b/index.html
@@ -193,12 +193,15 @@
       const experienceTimelineEl = document.getElementById("experience-timeline");
       const toolsGridEl = document.getElementById("tools-grid");
       const scrollTopButtonEl = document.getElementById("scroll-top-button");
+      const longestRoleLength = Math.max(...roles.map((role) => role.length));
       const mobileCardQuery = window.matchMedia("(max-width: 760px)");
       let mobileCardEffectsBound = false;
       let mobileCardEffectsTicking = false;
       let roleIndex = 0;
       let charIndex = roles[0].length;
       let deleting = true;
+
+      roleEl.style.setProperty("--typewriter-width", `${longestRoleLength + 1}ch`);
 
       function closeMobileMenu() {
         heroNavEl.classList.remove("is-open");


### PR DESCRIPTION
### Motivation
- The hero section's rotating role text caused the headline height to change as labels typed and deleted, which produced visible layout shifts for the page content beneath it.
- Reserve a stable horizontal space for the role text (based on the longest role) and keep it on a single line so the hero height does not reflow during the typewriter animation.

### Description
- Compute `longestRoleLength` from the `roles` array in `index.html` and set a CSS custom property `--typewriter-width` on the role element so the width can be driven from JS.
- Replace the previous `min-width` with `width: min(var(--typewriter-width, 18ch), 100%)` and add `min-height`, `overflow: hidden`, and `vertical-align: bottom` to the desktop `.typewriter-role` style in `index.css` to reserve space and prevent overflow-induced reflow.
- Apply the same fixed-width / `overflow: hidden` / `white-space: nowrap` behavior in the responsive/mobile `.typewriter-role` rules so the rotating label stays on one stable line on small screens.

### Testing
- Ran `git diff --check -- index.html index.css` and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc4d8854908326a43c298a584b5768)